### PR TITLE
Add admin page to show and create Gdpr requests

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,6 +11,11 @@ AllCops:
 RSpec/ExampleLength:
   Enabled: false
 
+RSpec/MultipleExpectations:
+  Enabled: true
+  Exclude:
+    - spec/features/**/*
+
 Metrics/BlockLength:
   Enabled: false
 

--- a/Rakefile
+++ b/Rakefile
@@ -28,6 +28,5 @@ end
 desc 'Generates a dummy app for testing'
 task :test_app do
   ENV['LIB_NAME'] = 'solidus_gdpr'
-  ENV['DB'] = 'postgresql'
   Rake::Task['extension:test_app'].invoke
 end

--- a/app/assets/javascripts/spree/backend/gdpr_requests/new.js
+++ b/app/assets/javascripts/spree/backend/gdpr_requests/new.js
@@ -1,0 +1,7 @@
+Spree.ready(function() {
+  if ($(".js-gdpr-request-user").length) {
+    new Spree.Views.Order.CustomerSelect({
+      el: $('#gdpr_request_user_id')
+    });
+  }
+});

--- a/app/assets/javascripts/spree/backend/solidus_gdpr.js
+++ b/app/assets/javascripts/spree/backend/solidus_gdpr.js
@@ -1,2 +1,4 @@
 // Placeholder manifest file.
 // the installer will append this file to the app vendored assets here: vendor/assets/javascripts/spree/backend/all.js'
+
+//= require_tree .

--- a/app/controllers/spree/admin/gdpr_requests_controller.rb
+++ b/app/controllers/spree/admin/gdpr_requests_controller.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Spree
+  module Admin
+    class GdprRequestsController < ResourceController
+      helper GdprRequestsHelper
+
+      def index
+        respond_with(@collection)
+      end
+
+      private
+
+      def collection
+        @collection ||=
+          Spree::GdprRequest
+            .order('served_at IS NOT NULL', created_at: :desc)
+            .page(params[:page] || 0)
+      end
+    end
+  end
+end

--- a/app/controllers/spree/admin/gdpr_requests_controller.rb
+++ b/app/controllers/spree/admin/gdpr_requests_controller.rb
@@ -12,6 +12,16 @@ module Spree
         respond_with(@collection)
       end
 
+      def serve
+        unless @object
+          redirect_to admin_gdpr_requests_path, flash: { error: t('gdpr.exports.error') }
+          return
+        end
+
+        @object.serve
+        redirect_to admin_gdpr_requests_path, notice: t('gdpr.exports.scheduled')
+      end
+
       private
 
       def collection

--- a/app/controllers/spree/admin/gdpr_requests_controller.rb
+++ b/app/controllers/spree/admin/gdpr_requests_controller.rb
@@ -3,7 +3,10 @@
 module Spree
   module Admin
     class GdprRequestsController < ResourceController
+      include GdprRequestsHelper
       helper GdprRequestsHelper
+
+      before_action :load_data
 
       def index
         respond_with(@collection)
@@ -16,6 +19,13 @@ module Spree
           Spree::GdprRequest
             .order('served_at IS NOT NULL', created_at: :desc)
             .page(params[:page] || 0)
+      end
+
+      def load_data
+        @users = Spree::User.order(:email)
+        @intents = Spree::GdprRequest.intents.collect do |slug, _index|
+          [title_case(slug), slug]
+        end
       end
     end
   end

--- a/app/helpers/gdpr_requests_helper.rb
+++ b/app/helpers/gdpr_requests_helper.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module GdprRequestsHelper
+  def title_case(text)
+    return '' unless text
+
+    text.split('_').map(&:capitalize).join(' ')
+  end
+end

--- a/app/models/spree/gdpr_request.rb
+++ b/app/models/spree/gdpr_request.rb
@@ -11,6 +11,7 @@ module Spree
     }
 
     validates :intent, presence: true
+    validates :user, presence: true
 
     def serve
       result = case intent.to_sym

--- a/app/views/spree/admin/gdpr_requests/_form.html.erb
+++ b/app/views/spree/admin/gdpr_requests/_form.html.erb
@@ -1,0 +1,30 @@
+<div data-hook="admin_gdpr_request_form_fields">
+  <div class="row">
+    <div class="left col-12" data-hook="admin_gdpr_request_form">
+      <div class="row">
+        <div class="col-6 js-gdpr-request-user" data-hook="admin_gdpr_request_form_user">
+          <%= f.field_container :user do %>
+            <%= f.label :user_id, Spree::GdprRequest.human_attribute_name(:user), class: 'required' %><br />
+            <%= f.hidden_field :user_id, class: 'fullwidth user_id' %>
+          <% end %>
+        </div>
+
+        <div class="col-6" data-hook="admin_gdpr_request_form_intent">
+          <%= f.field_container :intent do %>
+            <%= f.label :intent, Spree::GdprRequest.human_attribute_name(:intent), class: 'required' %><br />
+            <%= f.select :intent, @intents, { include_blank: true }, { class: 'custom-select fullwidth' } %>
+          <% end %>
+        </div>
+      </div>
+      <div class="row">
+        <div class="col-12" data-hook="admin_gdpr_request_form_user">
+          <%= f.field_container :notes do %>
+            <%= f.label :notes %>
+            <%= f.text_area :notes, class: 'fullwidth notes' %>
+            <%= f.error_message_on :notes %>
+          <% end %>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/spree/admin/gdpr_requests/index.html.erb
+++ b/app/views/spree/admin/gdpr_requests/index.html.erb
@@ -45,7 +45,9 @@
           <td class="actions" data-hook="admin_requests_index_row_actions">
             <% unless request.served_at %>
               <%= link_to_with_icon 'play', t('spree.actions.run'), serve_admin_gdpr_request_path(request),
-                class: 'play', method: :post if can?(:serve, request) %>
+                class: 'play serve-request', method: :post if can?(:serve, request) %>
+
+              <%= link_to_delete request, class: 'trash delete-request' if can?(:destroy, request) %>
             <% end %>
           </td>
         </tr>

--- a/app/views/spree/admin/gdpr_requests/index.html.erb
+++ b/app/views/spree/admin/gdpr_requests/index.html.erb
@@ -1,0 +1,63 @@
+<% admin_layout "full-width" %>
+
+<% admin_breadcrumb(plural_resource_name(Spree::GdprRequest)) %>
+
+<% content_for :page_actions do %>
+  <li>
+    <%= link_to t('spree.new_gdpr_request'), new_object_url, class: 'btn btn-primary' %>
+  </li>
+<% end if can?(:create, Spree::GdprRequest) %>
+
+<%= paginate @collection, theme: "solidus_admin" %>
+
+<% if @collection.any? %>
+  <table class="index" id="listing_gdpr_requests">
+    <colgroup>
+       <col style="width: 15%;">
+       <col style="width: 15%;">
+       <col style="width: 20%;">
+       <col style="width: 20%;">
+       <col style="width: 20%;">
+       <col style="width: 10%;">
+    </colgroup>
+    <thead>
+      <tr data-hook="admin_products_index_headers">
+        <th><%= Spree::GdprRequest.human_attribute_name(:user) %></th>
+        <th><%= Spree::GdprRequest.human_attribute_name(:intent) %></th>
+        <th><%= Spree::GdprRequest.human_attribute_name(:created_at) %></th>
+        <th><%= Spree::GdprRequest.human_attribute_name(:served_at) %></th>
+        <th><%= Spree::GdprRequest.human_attribute_name(:notes) %></th>
+        <th data-hook="admin_products_index_header_actions" class="actions"></th>
+      </tr>
+    </thead>
+    <tbody>
+      <% @collection.each do |request| %>
+        <tr id="<%= spree_dom_id request %>" data-hook="admin_requests_index_rows">
+          <td><%= link_to request.user.email, admin_user_path(request.user) %></td>
+          <td><%= title_case(request.intent) %></td>
+          <td><%= pretty_time(request.created_at) %></td>
+          <td>
+            <% if request.served_at %>
+              <%= pretty_time(request.served_at) %>
+            <% end %>
+          </td>
+          <td><%= request.notes %></td>
+          <td class="actions" data-hook="admin_requests_index_row_actions">
+            <% unless request.served_at %>
+              <%= link_to_with_icon 'play', t('spree.actions.run'), serve_admin_gdpr_request_path(request),
+                class: 'play', method: :post if can?(:serve, request) %>
+            <% end %>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+<% else %>
+  <div class="no-objects-found">
+    <%= render 'spree/admin/shared/no_objects_found',
+                  resource: Spree::GdprRequest,
+                  new_resource_url: new_object_url %>
+  </div>
+<% end %>
+
+<%= paginate @collection, theme: "solidus_admin" %>

--- a/app/views/spree/admin/gdpr_requests/new.html.erb
+++ b/app/views/spree/admin/gdpr_requests/new.html.erb
@@ -1,0 +1,13 @@
+<% admin_breadcrumb link_to(plural_resource_name(Spree::GdprRequest), spree.admin_gdpr_requests_path) %>
+<% admin_breadcrumb t('spree.new_gdpr_request') %>
+
+<%= render 'spree/shared/error_messages', target: @object %>
+
+<%= form_for [:admin, @object], method: :post, url: admin_gdpr_requests_path do |f| %>
+  <fieldset data-hook="new_gdpr_request">
+    <legend align="center"><%= t('spree.new_gdpr_request') %></legend>
+
+    <%= render 'form', f: f %>
+    <%= render 'spree/admin/shared/new_resource_links' %>
+  </fieldset>
+<% end %>

--- a/config/initializers/spree.rb
+++ b/config/initializers/spree.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+Spree::Backend::Config.configure do |config|
+  config.menu_items << config.class::MenuItem.new(
+    [:gdpr],
+    'user-secret',
+    condition: -> { can?(:admin, Spree::User) },
+    url: :admin_gdpr_requests_path
+  )
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2,6 +2,10 @@
 # See https://github.com/svenfuchs/rails-i18n/tree/master/rails%2Flocale for starting points.
 
 en:
+  gdpr:
+    exports:
+      scheduled: The data export will be emailed to the user shortly.
+      error: There was an error serving the request.
   spree:
     new_gdpr_request: New GDPR request
     admin:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2,4 +2,7 @@
 # See https://github.com/svenfuchs/rails-i18n/tree/master/rails%2Flocale for starting points.
 
 en:
-  hello: Hello world
+  spree:
+    admin:
+      tab:
+        gdpr: GDPR

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3,6 +3,9 @@
 
 en:
   spree:
+    new_gdpr_request: New GDPR request
     admin:
       tab:
         gdpr: GDPR
+    actions:
+      run: Run

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,7 @@
 
 Spree::Core::Engine.routes.draw do
   namespace :admin do
-    resources :gdpr_requests, only: %w[index new create] do
+    resources :gdpr_requests, only: %w[index new create destroy] do
       member do
         post :serve
       end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
 Spree::Core::Engine.routes.draw do
-  # Add your extension routes here
+  namespace :admin do
+    resources :gdpr_requests
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,10 @@
 
 Spree::Core::Engine.routes.draw do
   namespace :admin do
-    resources :gdpr_requests
+    resources :gdpr_requests, only: %w[index new create] do
+      member do
+        post :serve
+      end
+    end
   end
 end

--- a/lib/solidus_gdpr/factories.rb
+++ b/lib/solidus_gdpr/factories.rb
@@ -4,5 +4,9 @@ FactoryBot.define do
   factory :gdpr_request, class: 'Spree::GdprRequest' do
     intent { Spree::GdprRequest.intents.values.sample }
     user
+
+    trait :served do
+      served_at { Time.now }
+    end
   end
 end

--- a/solidus_gdpr.gemspec
+++ b/solidus_gdpr.gemspec
@@ -33,4 +33,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rubocop-rspec', '~> 1.35'
   s.add_development_dependency 'sass-rails'
   s.add_development_dependency 'simplecov'
+  s.add_development_dependency 'webdrivers'
 end

--- a/solidus_gdpr.gemspec
+++ b/solidus_gdpr.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'zeitwerk', '~> 2.1'
 
   s.add_development_dependency 'capybara'
+  s.add_development_dependency 'capybara-select2'
   s.add_development_dependency 'coffee-rails'
   s.add_development_dependency 'database_cleaner'
   s.add_development_dependency 'factory_bot_rails'

--- a/solidus_gdpr.gemspec
+++ b/solidus_gdpr.gemspec
@@ -25,7 +25,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'database_cleaner'
   s.add_development_dependency 'factory_bot_rails'
   s.add_development_dependency 'ffaker'
-  s.add_development_dependency 'pg'
   s.add_development_dependency 'poltergeist'
   s.add_development_dependency 'rspec-rails'
   s.add_development_dependency 'rspec-snapshot', '~> 0.1.2'
@@ -33,5 +32,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rubocop-rspec', '~> 1.35'
   s.add_development_dependency 'sass-rails'
   s.add_development_dependency 'simplecov'
+  s.add_development_dependency 'sqlite3'
   s.add_development_dependency 'webdrivers'
 end

--- a/spec/features/admin/gdpr/create_request_spec.rb
+++ b/spec/features/admin/gdpr/create_request_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'GDPR create request', type: :feature, js: true do
+  include Warden::Test::Helpers
+
+  let(:admin_user) { create(:admin_user) }
+
+  before do
+    login_as admin_user
+
+    visit spree.admin_gdpr_requests_path
+  end
+
+  context 'when the form is filled with the correct information' do
+    it 'creates the request' do
+      expect(page).not_to have_selector('[data-hook="admin_requests_index_rows"]')
+
+      click_on 'New GDPR request'
+
+      select2(admin_user.email, from: 'User')
+      find('#gdpr_request_intent').find(:xpath, 'option[2]').select_option
+
+      click_on 'Create'
+      expect(page).to have_selector('[data-hook="admin_requests_index_rows"]')
+    end
+  end
+
+  context 'when the form is filled with the wrong information' do
+    it 'shows error messages' do
+      click_on 'New GDPR request'
+      click_on 'Create'
+
+      expect(page).to have_selector('#errorExplanation')
+    end
+  end
+end

--- a/spec/features/admin/gdpr/request_actions_spec.rb
+++ b/spec/features/admin/gdpr/request_actions_spec.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'GDPR request actions', type: :feature, js: true do
+  include Warden::Test::Helpers
+
+  let(:admin_user) { create(:admin_user) }
+
+  before { login_as admin_user }
+
+  context 'when a request is already served' do
+    before do
+      create(:gdpr_request, :served, user: admin_user)
+
+      visit spree.admin_gdpr_requests_path
+    end
+
+    it 'does not show the run and delete actions' do
+      expect(page).not_to have_selector('.serve-request')
+      expect(page).not_to have_selector('.delete-request')
+    end
+  end
+
+  context 'when a request is not served yet' do
+    before do
+      create(:gdpr_request, user: admin_user)
+
+      visit spree.admin_gdpr_requests_path
+    end
+
+    it 'shows the run and delete actions' do
+      expect(page).to have_selector('.serve-request')
+      expect(page).to have_selector('.delete-request')
+    end
+  end
+
+  describe 'GDPR serve' do
+    let!(:request) { create(:gdpr_request, intent: 'data_erasure', user: admin_user) }
+
+    before { visit spree.admin_gdpr_requests_path }
+
+    it 'serves the request' do
+      expect(request.served_at).to eq(nil)
+      find('.serve-request').click
+      expect(request.reload.served_at).not_to eq(nil)
+    end
+  end
+
+  describe 'GDPR delete' do
+    before do
+      create(:gdpr_request, user: admin_user)
+
+      visit spree.admin_gdpr_requests_path
+    end
+
+    it 'serves the request' do
+      page.accept_alert 'Are you sure?' do
+        find('.delete-request').click
+      end
+
+      expect(page).not_to have_selector('[data-hook="admin_requests_index_rows"]')
+    end
+  end
+end

--- a/spec/features/admin/gdpr/requests_spec.rb
+++ b/spec/features/admin/gdpr/requests_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'GDPR requests', type: :feature, js: true do
+  include Warden::Test::Helpers
+
+  let(:admin_user) { create(:admin_user) }
+
+  before { login_as admin_user }
+
+  context 'when there aren\'t any requests' do
+    before { visit spree.admin_gdpr_requests_path }
+
+    it 'shows empty message' do
+      expect(page).to have_selector('.no-objects-found')
+    end
+  end
+
+  context 'when there are requests' do
+    context 'when there are fewer than 25 requests' do
+      before do
+        create(:gdpr_request, :served, intent: 'data_export', user: admin_user)
+        create(:gdpr_request, intent: 'data_erasure', user: admin_user)
+        create(:gdpr_request, intent: 'data_restriction', user: admin_user)
+
+        visit spree.admin_gdpr_requests_path
+      end
+
+      it 'does not show pagination' do
+        expect(page).not_to have_selector('.pagination')
+      end
+
+      it 'shows the list of requests ordered by served_at and completed_at desc' do
+        expect(page).to have_selector('[data-hook="admin_requests_index_rows"]', count: 3)
+
+        within all('[data-hook="admin_requests_index_rows"]').first do
+          expect(page).to have_text('Data Restriction')
+        end
+
+        within all('[data-hook="admin_requests_index_rows"]')[1] do
+          expect(page).to have_text('Data Erasure')
+        end
+
+        within all('[data-hook="admin_requests_index_rows"]').last do
+          expect(page).to have_text('Data Export')
+        end
+      end
+    end
+
+    context 'when there are more than 25 requests' do
+      before do
+        create_list(:gdpr_request, 30, user: admin_user)
+
+        visit spree.admin_gdpr_requests_path
+      end
+
+      it 'shows pagination' do
+        expect(page).to have_selector('.pagination', count: 2)
+      end
+    end
+  end
+end

--- a/spec/features/admin/sidebar_spec.rb
+++ b/spec/features/admin/sidebar_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'Sidebar', type: :feature, js: true do
+  include Warden::Test::Helpers
+
+  let(:admin_user) { create(:admin_user) }
+
+  before do
+    login_as admin_user
+
+    visit spree.admin_path
+  end
+
+  it 'shows GDPR menu item in the sidebar' do
+    within '[data-hook="admin_tabs"]' do
+      expect(page).to have_text('GDPR')
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -21,6 +21,7 @@ require 'rspec/rails'
 require 'database_cleaner'
 require 'ffaker'
 require 'rspec/snapshot'
+require 'webdrivers'
 
 # Requires supporting ruby files with custom matchers and macros, etc,
 # in spec/support/ and its subdirectories.
@@ -49,6 +50,9 @@ module SerializerHelpers
     end
   end
 end
+
+Capybara.javascript_driver = :selenium_chrome_headless
+Capybara.server = :webrick
 
 RSpec.configure do |config|
   config.include FactoryBot::Syntax::Methods


### PR DESCRIPTION
Add the `GDPR` menu item to the Solidus admin sidebar.
Shows all the requests with the `run` button if it isn't served yet.

![image](https://user-images.githubusercontent.com/9986708/64172080-72328900-ce54-11e9-8348-8f6a21a1631f.png)
![image](https://user-images.githubusercontent.com/9986708/64172106-7e1e4b00-ce54-11e9-82ea-e35db376b421.png)
